### PR TITLE
Fix namespace setup for auth and mail services

### DIFF
--- a/BLL/DTO/RegisterRequest.cs
+++ b/BLL/DTO/RegisterRequest.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
+
+namespace BLL.DTO;
 
 public class RegisterRequest
 {

--- a/BLL/Services/MailService/SmtpEmailSender.cs
+++ b/BLL/Services/MailService/SmtpEmailSender.cs
@@ -1,18 +1,18 @@
-﻿// Services/MailSettings.cs
 using System.Net;
 using System.Net.Mail;
 using Microsoft.Extensions.Options;
 
+namespace BLL.Services.MailService;
+
 public class MailSettings
 {
-    public string Host { get; set; } = "";
+    public string Host { get; set; } = string.Empty;
     public int Port { get; set; } = 587;
-    public string UserName { get; set; } = "";
-    public string Password { get; set; } = "";
-    public string? From { get; set; }           // có thể null/empty
+    public string UserName { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string? From { get; set; }
     public bool EnableSsl { get; set; } = true;
 }
-
 
 public class SmtpEmailSender
 {
@@ -41,8 +41,8 @@ public class SmtpEmailSender
         using var msg = new MailMessage()
         {
             From = from,
-            Subject = subject ?? "",
-            Body = htmlBody ?? "",
+            Subject = subject ?? string.Empty,
+            Body = htmlBody ?? string.Empty,
             IsBodyHtml = true
         };
         msg.To.Add(to);

--- a/BLL/Services/UsersService/UserService.cs
+++ b/BLL/Services/UsersService/UserService.cs
@@ -1,10 +1,8 @@
-﻿using BLL.Helper;
-using DAL;
+using BLL.Helper;
 using DAL.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace BLL.Services;
-
 
 public class UserService
 {
@@ -20,31 +18,29 @@ public class UserService
 
         var stored = user.Password;
 
-
         if (PasswordHelper.LooksLikeBCrypt(stored))
         {
             return BCrypt.Net.BCrypt.Verify(password, stored) ? user : null;
         }
 
-
         if (stored == password)
         {
             var newHash = BCrypt.Net.BCrypt.HashPassword(password);
-            user.Password = newHash;   
-            await _context.SaveChangesAsync(); 
+            user.Password = newHash;
+            await _context.SaveChangesAsync();
             return user;
         }
 
-      
         return null;
     }
+
     public async Task<User> RegisterAsync(string username, string rawPassword, string role = "User")
     {
         var hash = BCrypt.Net.BCrypt.HashPassword(rawPassword);
         var user = new User
         {
             UserName = username,
-            Password = hash, 
+            Password = hash,
             Role = role
         };
         _context.Users.Add(user);
@@ -66,5 +62,3 @@ public class UserService
     }
 
 }
-
-

--- a/BLL/Services/UsersService/UserService.cs
+++ b/BLL/Services/UsersService/UserService.cs
@@ -2,7 +2,7 @@ using BLL.Helper;
 using DAL.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace BLL.Services;
+namespace BLL.Services.UsersService;
 
 public class UserService
 {

--- a/WebNameProjectOfSWD/Controllers/AuthController.cs
+++ b/WebNameProjectOfSWD/Controllers/AuthController.cs
@@ -1,8 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.Net.Mail;
 using BLL.DTO;
 using BLL.DTO.UserDto;
-using BLL.Services;
+using BLL.Services.UsersService;
 using BLL.Services.Jwt;
 using BLL.Services.MailService;
 using DAL;

--- a/WebNameProjectOfSWD/Controllers/AuthController.cs
+++ b/WebNameProjectOfSWD/Controllers/AuthController.cs
@@ -4,6 +4,7 @@ using BLL.DTO;
 using BLL.DTO.UserDto;
 using BLL.Services;
 using BLL.Services.Jwt;
+using BLL.Services.MailService;
 using DAL;
 using DAL.Models;
 using Microsoft.AspNetCore.Authorization;

--- a/WebNameProjectOfSWD/Program.cs
+++ b/WebNameProjectOfSWD/Program.cs
@@ -1,5 +1,6 @@
 ﻿using BLL.Services;
 using BLL.Services.Jwt;
+using BLL.Services.MailService;
 using DAL;
 using DAL.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;

--- a/WebNameProjectOfSWD/Program.cs
+++ b/WebNameProjectOfSWD/Program.cs
@@ -1,4 +1,4 @@
-﻿using BLL.Services;
+using BLL.Services.UsersService;
 using BLL.Services.Jwt;
 using BLL.Services.MailService;
 using DAL;


### PR DESCRIPTION
## Summary
- add the missing BLL.DTO namespace declaration for the register request DTO
- place mail settings and SMTP sender in the BLL.Services.MailService namespace and update consumers
- fix the user service to reference DAL models directly so authentication helpers resolve correctly

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e369d6d3bc8321a3ea6cefc603b2d4